### PR TITLE
fix: enable scrolling in sheets

### DIFF
--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -56,7 +56,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 overflow-y-auto shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&


### PR DESCRIPTION
## Summary
- enable scrolling inside sheet content so users can reach overflowing content

## Testing
- `pnpm test` *(fails: PluginImportError; no test files found)*
- `pnpm lint` *(fails: 42 errors including parse errors in styles.css)*

------
https://chatgpt.com/codex/tasks/task_e_6894f81bf6148325a3650cdcbf60af04

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enabled vertical scrolling within the sheet content area to improve usability when content exceeds the visible space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->